### PR TITLE
feat: Markdown を Slack mrkdwn 形式に自動変換

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -209,6 +210,89 @@ func processFileFromPosition(filePath string, startPosition int64, api *slack.Cl
 	return currentPosition
 }
 
+// convertMarkdownToSlack converts Markdown-formatted text to Slack mrkdwn format.
+// It skips content inside fenced code blocks to preserve their formatting.
+func convertMarkdownToSlack(text string) string {
+	// Split on fenced code blocks so we don't mangle their contents.
+	codeBlockRe := regexp.MustCompile("(?s)```.*?```")
+
+	var result strings.Builder
+	lastIndex := 0
+	for _, loc := range codeBlockRe.FindAllStringIndex(text, -1) {
+		result.WriteString(convertMarkdownSyntax(text[lastIndex:loc[0]]))
+		result.WriteString(text[loc[0]:loc[1]])
+		lastIndex = loc[1]
+	}
+	result.WriteString(convertMarkdownSyntax(text[lastIndex:]))
+	return result.String()
+}
+
+// convertMarkdownSyntax applies mrkdwn conversions to a non-code-block segment.
+func convertMarkdownSyntax(text string) string {
+	// Tables first (multi-line structure)
+	text = convertTables(text)
+
+	// Headers: # Title -> *Title*
+	// Use a placeholder (\x00) so the italic pass below doesn't re-convert them.
+	headerRe := regexp.MustCompile(`(?m)^#{1,6}\s+(.+)$`)
+	text = headerRe.ReplaceAllString(text, "\x00${1}\x00")
+
+	// Bold: **text** or __text__ -> *text*
+	// Also use the placeholder for the same reason.
+	boldRe := regexp.MustCompile(`\*\*(.+?)\*\*`)
+	text = boldRe.ReplaceAllString(text, "\x00${1}\x00")
+	boldUnderRe := regexp.MustCompile(`__(.+?)__`)
+	text = boldUnderRe.ReplaceAllString(text, "\x00${1}\x00")
+
+	// Italic: *text* -> _text_ (only remaining single-asterisk pairs)
+	// Use ${1} to avoid Go regexp treating the trailing _ as part of the group name.
+	italicRe := regexp.MustCompile(`\*([^*\n]+?)\*`)
+	text = italicRe.ReplaceAllString(text, "_${1}_")
+
+	// Restore bold/header placeholders as Slack bold markers.
+	text = strings.ReplaceAll(text, "\x00", "*")
+
+	// Strikethrough: ~~text~~ -> ~text~
+	strikeRe := regexp.MustCompile(`~~(.+?)~~`)
+	text = strikeRe.ReplaceAllString(text, "~$1~")
+
+	// Links: [label](url) -> <url|label>
+	linkRe := regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+	text = linkRe.ReplaceAllString(text, "<$2|$1>")
+
+	return text
+}
+
+// convertTables wraps Markdown table blocks in fenced code blocks so they
+// render as monospace text in Slack (which has no native table support).
+func convertTables(text string) string {
+	lines := strings.Split(text, "\n")
+	result := make([]string, 0, len(lines))
+	inTable := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		isTableRow := strings.HasPrefix(trimmed, "|")
+		if isTableRow {
+			if !inTable {
+				result = append(result, "```")
+				inTable = true
+			}
+			result = append(result, line)
+		} else {
+			if inTable {
+				result = append(result, "```")
+				inTable = false
+			}
+			result = append(result, line)
+		}
+	}
+	if inTable {
+		result = append(result, "```")
+	}
+	return strings.Join(result, "\n")
+}
+
 func processBuffer(jsonBuffer *strings.Builder, api *slack.Client, channelID, threadTS string, debugMode bool) {
 	jsonStr := jsonBuffer.String()
 	jsonStr = strings.TrimSpace(jsonStr)
@@ -243,7 +327,7 @@ func processBuffer(jsonBuffer *strings.Builder, api *slack.Client, channelID, th
 
 	// If there are text outputs, either post to Slack or print to stdout
 	if len(textOutputs) > 0 {
-		textMessage := strings.Join(textOutputs, "\n")
+		textMessage := convertMarkdownToSlack(strings.Join(textOutputs, "\n"))
 
 		if debugMode {
 			// Debug mode: print to stdout

--- a/main_test.go
+++ b/main_test.go
@@ -142,6 +142,84 @@ func TestContentItem(t *testing.T) {
 	}
 }
 
+func TestConvertMarkdownToSlack(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "bold double asterisk",
+			input:    "**bold text**",
+			expected: "*bold text*",
+		},
+		{
+			name:     "bold double underscore",
+			input:    "__bold text__",
+			expected: "*bold text*",
+		},
+		{
+			name:     "italic single asterisk",
+			input:    "*italic text*",
+			expected: "_italic text_",
+		},
+		{
+			name:     "italic underscore unchanged",
+			input:    "_italic text_",
+			expected: "_italic text_",
+		},
+		{
+			name:     "header h1",
+			input:    "# My Title",
+			expected: "*My Title*",
+		},
+		{
+			name:     "header h3",
+			input:    "### Sub Title",
+			expected: "*Sub Title*",
+		},
+		{
+			name:     "strikethrough",
+			input:    "~~deleted~~",
+			expected: "~deleted~",
+		},
+		{
+			name:     "link",
+			input:    "[GitHub](https://github.com)",
+			expected: "<https://github.com|GitHub>",
+		},
+		{
+			name:     "bold and italic mixed",
+			input:    "**bold** and *italic*",
+			expected: "*bold* and _italic_",
+		},
+		{
+			name:     "code block preserved",
+			input:    "before\n```\n**not bold**\n```\nafter **bold**",
+			expected: "before\n```\n**not bold**\n```\nafter *bold*",
+		},
+		{
+			name:  "table wrapped in code block",
+			input: "| Name | Value |\n|------|-------|\n| foo  | 123   |",
+			expected: "```\n| Name | Value |\n|------|-------|\n| foo  | 123   |\n```",
+		},
+		{
+			name:     "no markdown",
+			input:    "plain text message",
+			expected: "plain text message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertMarkdownToSlack(tt.input)
+			if got != tt.expected {
+				t.Errorf("convertMarkdownToSlack(%q)\n  got:  %q\n  want: %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestViperConfiguration(t *testing.T) {
 	viper.Reset()
 

--- a/main_test.go
+++ b/main_test.go
@@ -199,8 +199,8 @@ func TestConvertMarkdownToSlack(t *testing.T) {
 			expected: "before\n```\n**not bold**\n```\nafter *bold*",
 		},
 		{
-			name:  "table wrapped in code block",
-			input: "| Name | Value |\n|------|-------|\n| foo  | 123   |",
+			name:     "table wrapped in code block",
+			input:    "| Name | Value |\n|------|-------|\n| foo  | 123   |",
 			expected: "```\n| Name | Value |\n|------|-------|\n| foo  | 123   |\n```",
 		},
 		{


### PR DESCRIPTION
## Summary

- Claude の出力は Markdown 形式だが、そのまま Slack に投稿しても書式が効かない問題を修正
- `convertMarkdownToSlack` 関数を追加し、`processBuffer` 内で投稿前に自動変換するよう実装

## 変換対応内容

| Markdown | Slack mrkdwn | 備考 |
|---|---|---|
| `**bold**` / `__bold__` | `*bold*` | Slack 太文字 |
| `*italic*` | `_italic_` | Slack 斜体 |
| `# Header` | `*Header*` | 太文字で代用 |
| `~~strike~~` | `~strike~` | 打ち消し線 |
| `[text](url)` | `<url\|text>` | リンク |
| テーブル | コードブロック | Slack はテーブル非対応のため等幅表示 |
| コードブロック内 | 変換スキップ | フォーマット保護 |

## 実装メモ

- Go の `regexp.ReplaceAllString` で `"_$1_"` のように書くと `$1_` がグループ名として解釈されてしまうため、`"_${1}_"` の形式を使用
- 見出し・太文字はプレースホルダー（`\x00`）経由で変換し、italic パスで誤変換されないよう保護

## Test plan

- [x] `go test ./...` 通過
- [x] `go vet ./...` 通過
- [x] `go build ./...` 通過
- [ ] CI 確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)